### PR TITLE
Allow GET requests to /api/categories and add error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,0 +1,50 @@
+const request = require("supertest");
+const seed = require("../db/seeds/seed");
+const testData = require("../db/data/test-data");
+const app = require("../app");
+const db = require("../db/connection");
+
+beforeEach(() => seed(testData));
+afterAll(() => db.end());
+
+describe("Invalid endpoint", () => {
+  test("should return a 404 status code and an error message of 'Endpoint does not exist'", () => {
+    return request(app)
+      .get("/api/category")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Endpoint does not exist");
+      });
+  });
+});
+
+describe("/api/categories", () => {
+  describe("GET", () => {
+    test("should return a status code of 200", () => {
+      return request(app).get("/api/categories").expect(200);
+    });
+  });
+  test("should return an array of 4 items on a category property", () => {
+    return request(app)
+      .get("/api/categories")
+      .then(({ body }) => {
+        expect(body.categories).toBeInstanceOf(Array);
+        expect(body.categories).toHaveLength(4);
+      });
+  });
+  test("should return objects with the slug and description properties", () => {
+    return request(app)
+      .get("/api/categories")
+      .then(({ body }) => {
+        const { categories } = body;
+        categories.forEach((category) => {
+          expect(category).toEqual(
+            expect.objectContaining({
+              slug: expect.any(String),
+              description: expect.any(String),
+            })
+          );
+        });
+      });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const { getCategories } = require("./controllers/controllers");
+
+const app = express();
+
+app.get("/api/categories", getCategories);
+
+app.all("/*", (req, res) => {
+  res.status(404).send({ msg: "Endpoint does not exist" });
+});
+
+module.exports = app;

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,0 +1,7 @@
+const { fetchCategories } = require("../models/models");
+
+exports.getCategories = (req, res, next) => {
+  fetchCategories().then((categories) => {
+    res.status(200).send({ categories });
+  });
+};

--- a/models/models.js
+++ b/models/models.js
@@ -1,0 +1,7 @@
+const db = require("../db/connection");
+
+exports.fetchCategories = () => {
+  return db.query("SELECT * FROM categories").then(({ rows: categories }) => {
+    return categories;
+  });
+};


### PR DESCRIPTION
**GET /api/categories**

This will create an endpoint for /api/categories that returns a status code of 200, as well as an array of category objects on a property of categories. It also creates the relevant controllers and models directories/files for future endpoints, as well as setting up the test suite with in-built reseeding and connection closing.

**Error handling**

Error handling for trying to access an invalid endpoint now exists, returning a 404 error code and an error message of 'Endpoint does not exist".