### PR TITLE
Add ability to search for review by review ID

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -23,28 +23,72 @@ describe("/api/categories", () => {
     test("should return a status code of 200", () => {
       return request(app).get("/api/categories").expect(200);
     });
+    test("should return an array of 4 items on a category property", () => {
+      return request(app)
+        .get("/api/categories")
+        .then(({ body }) => {
+          expect(body.categories).toBeInstanceOf(Array);
+          expect(body.categories).toHaveLength(4);
+        });
+    });
+    test("should return objects with the slug and description properties", () => {
+      return request(app)
+        .get("/api/categories")
+        .then(({ body }) => {
+          const { categories } = body;
+          categories.forEach((category) => {
+            expect(category).toEqual(
+              expect.objectContaining({
+                slug: expect.any(String),
+                description: expect.any(String),
+              })
+            );
+          });
+        });
+    });
   });
-  test("should return an array of 4 items on a category property", () => {
-    return request(app)
-      .get("/api/categories")
-      .then(({ body }) => {
-        expect(body.categories).toBeInstanceOf(Array);
-        expect(body.categories).toHaveLength(4);
-      });
-  });
-  test("should return objects with the slug and description properties", () => {
-    return request(app)
-      .get("/api/categories")
-      .then(({ body }) => {
-        const { categories } = body;
-        categories.forEach((category) => {
-          expect(category).toEqual(
+});
+
+describe("/api/reviews/:review_id", () => {
+  describe("GET", () => {
+    test("returns a status code of 200", () => {
+      return request(app).get("/api/reviews/1").expect(200);
+    });
+    test("returns a single review object on a property of review with the keys review_id, title, review_body, designer, review_img_url, votes, category, owner, and created_at", () => {
+      return request(app)
+        .get("/api/reviews/1")
+        .then(({ body }) => {
+          const review = body.review;
+          expect(review).toEqual(
             expect.objectContaining({
-              slug: expect.any(String),
-              description: expect.any(String),
+              review_id: expect.any(Number),
+              title: expect.any(String),
+              review_body: expect.any(String),
+              designer: expect.any(String),
+              review_img_url: expect.any(String),
+              votes: expect.any(Number),
+              category: expect.any(String),
+              owner: expect.any(String),
+              created_at: expect.any(String),
             })
           );
         });
-      });
+    });
+    test("returns a 404 status code and an error message when a user searches for a valid ID that does not exist in the database", () => {
+      return request(app)
+        .get("/api/reviews/100000")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Review does not exist");
+        });
+    });
+    test("returns a 400 status code and an error message when a user searches for an invalid ID", () => {
+      return request(app)
+        .get("/api/reviews/myfavouritereview")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Please enter a valid ID");
+        });
+    });
   });
 });

--- a/app.js
+++ b/app.js
@@ -1,12 +1,24 @@
 const express = require("express");
-const { getCategories } = require("./controllers/controllers");
+const { getCategories, getReviewById } = require("./controllers/controllers");
 
 const app = express();
 
 app.get("/api/categories", getCategories);
 
+app.get("/api/reviews/:review_id", getReviewById);
+
 app.all("/*", (req, res) => {
   res.status(404).send({ msg: "Endpoint does not exist" });
+});
+
+// Error-handling middleware functions
+
+app.use((err, req, res, next) => {
+  if (err.code === "22P02") {
+    res.status(400).send({ msg: "Please enter a valid ID" });
+  } else {
+    res.status(err.status).send({ msg: err.msg });
+  }
 });
 
 module.exports = app;

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,7 +1,18 @@
-const { fetchCategories } = require("../models/models");
+const { fetchCategories, selectReview } = require("../models/models");
 
 exports.getCategories = (req, res, next) => {
   fetchCategories().then((categories) => {
     res.status(200).send({ categories });
   });
+};
+
+exports.getReviewById = (req, res, next) => {
+  const { review_id } = req.params;
+  selectReview(review_id)
+    .then((review) => {
+      res.status(200).send({ review });
+    })
+    .catch((err) => {
+      next(err);
+    });
 };

--- a/models/models.js
+++ b/models/models.js
@@ -5,3 +5,13 @@ exports.fetchCategories = () => {
     return categories;
   });
 };
+
+exports.selectReview = (review_id) => {
+  return db
+    .query("SELECT * FROM reviews WHERE review_id = $1", [review_id])
+    .then(({ rows: review }) => {
+      return review.length > 0
+        ? review[0]
+        : Promise.reject({ status: 404, msg: "Review does not exist" });
+    });
+};


### PR DESCRIPTION
**GET /api/reviews/:review_id**

Added the ability for users to make a GET request to the /api/reviews/:review_id endpoint, returning a single object on a 'review' key.

**Error handling**

Added error handling for invalid ID requests (400) and valid ID requests that return no review (404).

**Misc**

I also rearranged the existing tests to make them appear neater in the terminal.