### PR TITLE
Add PATCH method to the reviews endpoint and include error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -91,4 +91,69 @@ describe("/api/reviews/:review_id", () => {
         });
     });
   });
+  describe("PATCH", () => {
+    test("returns a status code of 200", () => {
+      return request(app)
+        .patch("/api/reviews/1")
+        .send({ inc_votes: 1 })
+        .expect(200);
+    });
+    test("returns an object with the votes property increased by the correct amount", () => {
+      return request(app)
+        .get("/api/reviews/1")
+        .then(({ body: { review } }) => {
+          const { votes: beforeVotes } = review;
+          return request(app)
+            .patch("/api/reviews/1")
+            .send({ inc_votes: 1 })
+            .then(({ body: { review } }) => {
+              const { votes: newVotes } = review;
+              expect(newVotes).toBe(beforeVotes + 1);
+            });
+        });
+    });
+    test("returns an object with the votes property decreased by the correct amount", () => {
+      return request(app)
+        .get("/api/reviews/1")
+        .then(({ body: { review } }) => {
+          const { votes: beforeVotes } = review;
+          return request(app)
+            .patch("/api/reviews/1")
+            .send({ inc_votes: -30 })
+            .then(({ body: { review } }) => {
+              const { votes: newVotes } = review;
+              expect(newVotes).toBe(beforeVotes - 30);
+            });
+        });
+    });
+    test("returns a 400 status code and error message when the request body does not contain the correct key-value pair", () => {
+      return request(app)
+        .patch("/api/reviews/1")
+        .send({ votes: 3 })
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe(
+            "No valid vote change was included on the request body"
+          );
+        });
+    });
+    test("returns a 404 status code and an error message when a user searches for a valid ID that does not exist in the database", () => {
+      return request(app)
+        .patch("/api/reviews/10000")
+        .send({ inc_votes: 3 })
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Review does not exist");
+        });
+    });
+    test("returns a 400 status code and an error message when a user searches for an invalid ID", () => {
+      return request(app)
+        .patch("/api/reviews/myfavouritereview")
+        .send({ inc_votes: 3 })
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Invalid PSQL input");
+        });
+    });
+  });
 });

--- a/app.js
+++ b/app.js
@@ -1,5 +1,9 @@
 const express = require("express");
-const { getCategories, getReviewById } = require("./controllers/controllers");
+const {
+  getCategories,
+  getReviewById,
+  patchReview,
+} = require("./controllers/controllers");
 const {
   handleCustomErrors,
   handlePsqlErrors,
@@ -8,9 +12,12 @@ const {
 
 const app = express();
 
+app.use(express.json());
+
 app.get("/api/categories", getCategories);
 
 app.get("/api/reviews/:review_id", getReviewById);
+app.patch("/api/reviews/:review_id", patchReview);
 
 app.all("/*", (req, res) => {
   res.status(404).send({ msg: "Endpoint does not exist" });

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,8 @@
-const { fetchCategories, selectReview } = require("../models/models");
+const {
+  fetchCategories,
+  selectReview,
+  updateReview,
+} = require("../models/models");
 
 exports.getCategories = (req, res, next) => {
   fetchCategories().then((categories) => {
@@ -9,6 +13,18 @@ exports.getCategories = (req, res, next) => {
 exports.getReviewById = (req, res, next) => {
   const { review_id } = req.params;
   selectReview(review_id)
+    .then((review) => {
+      res.status(200).send({ review });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.patchReview = (req, res, next) => {
+  const { review_id } = req.params;
+  const { inc_votes } = req.body;
+  updateReview(review_id, inc_votes)
     .then((review) => {
       res.status(200).send({ review });
     })

--- a/errors/index.js
+++ b/errors/index.js
@@ -7,6 +7,10 @@ exports.handleCustomErrors = (err, req, res, next) => {
 exports.handlePsqlErrors = (err, req, res, next) => {
   if (err.code === "22P02") {
     res.status(400).send({ msg: "Invalid PSQL input" });
+  } else if (err.code === "23502") {
+    res
+      .status(400)
+      .send({ msg: "Attempted to insert null into a not-null constraint" });
   } else next(err);
 };
 

--- a/models/models.js
+++ b/models/models.js
@@ -15,3 +15,22 @@ exports.selectReview = (review_id) => {
         : Promise.reject({ status: 404, msg: "Review does not exist" });
     });
 };
+
+exports.updateReview = (review_id, voteChange) => {
+  if (isNaN(voteChange)) {
+    return Promise.reject({
+      status: 400,
+      msg: "No valid vote change was included on the request body",
+    });
+  }
+  return db
+    .query(
+      "UPDATE reviews SET votes = votes + $1 WHERE review_id = $2 RETURNING *",
+      [voteChange, review_id]
+    )
+    .then(({ rows: review }) => {
+      return review.length > 0
+        ? review[0]
+        : Promise.reject({ status: 404, msg: "Review does not exist" });
+    });
+};


### PR DESCRIPTION
**PATCH /api/reviews/:review_id**

Added PATCH as a valid method for the /api/reviews/:review_id endpoint, increasing the votes value on a specified object by a requested amount. It then returns the updated object.

**Error handling**

Added error handling for valid review_ids that don't exist in the database, invalid review_ids, request bodies that do not contain the inc_votes key, and non-integer values against the inc_votes key.