### PR TITLE
Add /api/users endpoint with the GET method

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -168,3 +168,34 @@ describe("/api/reviews/:review_id", () => {
     });
   });
 });
+
+describe("/api/users", () => {
+  describe("GET", () => {
+    test("returns a status code of 200", () => {
+      return request(app).get("/api/users").expect(200);
+    });
+    test("returns an array of all user objects", () => {
+      return request(app)
+        .get("/api/users")
+        .then(({ body }) => {
+          expect(body.users).toBeInstanceOf(Array);
+          expect(body.users).toHaveLength(4);
+        });
+    });
+    test("returns the correct properties on each user object", () => {
+      return request(app)
+        .get("/api/users")
+        .then(({ body }) => {
+          body.users.forEach((user) => {
+            expect(user).toEqual(
+              expect.objectContaining({
+                username: expect.any(String),
+                name: expect.any(String),
+                avatar_url: expect.any(String),
+              })
+            );
+          });
+        });
+    });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const {
   getCategories,
   getReviewById,
   patchReview,
+  getUsers,
 } = require("./controllers/controllers");
 const {
   handleCustomErrors,
@@ -18,6 +19,8 @@ app.get("/api/categories", getCategories);
 
 app.get("/api/reviews/:review_id", getReviewById);
 app.patch("/api/reviews/:review_id", patchReview);
+
+app.get("/api/users", getUsers);
 
 app.all("/*", (req, res) => {
   res.status(404).send({ msg: "Endpoint does not exist" });

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -2,6 +2,7 @@ const {
   fetchCategories,
   selectReview,
   updateReview,
+  fetchUsers,
 } = require("../models/models");
 
 exports.getCategories = (req, res, next) => {
@@ -31,4 +32,10 @@ exports.patchReview = (req, res, next) => {
     .catch((err) => {
       next(err);
     });
+};
+
+exports.getUsers = (req, res, next) => {
+  fetchUsers().then((users) => {
+    res.status(200).send({ users });
+  });
 };

--- a/models/models.js
+++ b/models/models.js
@@ -34,3 +34,7 @@ exports.updateReview = (review_id, voteChange) => {
         : Promise.reject({ status: 404, msg: "Review does not exist" });
     });
 };
+
+exports.fetchUsers = () => {
+  return db.query("SELECT * FROM users").then(({ rows: users }) => users);
+};


### PR DESCRIPTION
**GET /api/users**

Added functionality for making a GET request to the /api/users endpoint, returning an array of user objects with the correct properties against a 'users' key. Error-handling for this includes making the request to an invalid endpoint (e.g. /api/user), which was handled in ticket #3.