### PR TITLE
Add /api/reviews as endpoint and add functionality for the GET method

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,5 +1,6 @@
 const request = require("supertest");
 const seed = require("../db/seeds/seed");
+const jestsorted = require("jest-sorted");
 const testData = require("../db/data/test-data");
 const app = require("../app");
 const db = require("../db/connection");
@@ -220,6 +221,56 @@ describe("/api/users", () => {
               })
             );
           });
+        });
+    });
+  });
+});
+
+describe("/api/reviews", () => {
+  describe("GET", () => {
+    test("returns a status code of 200", () => {
+      return request(app).get("/api/reviews").expect(200);
+    });
+    test("returns an array of review objects against a property of reviews", () => {
+      return request(app)
+        .get("/api/reviews")
+        .then(({ body }) => {
+          expect(body.reviews).toBeInstanceOf(Array);
+        });
+    });
+    test("returns all review objects in the database", () => {
+      return request(app)
+        .get("/api/reviews")
+        .then(({ body }) => {
+          expect(body.reviews).toHaveLength(13);
+        });
+    });
+    test("every review object contains the correct properties", () => {
+      return request(app)
+        .get("/api/reviews")
+        .then(({ body }) => {
+          body.reviews.forEach((review) => {
+            expect(review).toEqual(
+              expect.objectContaining({
+                owner: expect.any(String),
+                title: expect.any(String),
+                review_id: expect.any(Number),
+                category: expect.any(String),
+                review_img_url: expect.any(String),
+                created_at: expect.any(String),
+                votes: expect.any(Number),
+                designer: expect.any(String),
+                comment_count: expect.any(Number),
+              })
+            );
+          });
+        });
+    });
+    test("reviews are returned in descending order according to date", () => {
+      return request(app)
+        .get("/api/reviews")
+        .then(({ body }) => {
+          expect(body.reviews).toBeSortedBy("created_at", { descending: true });
         });
     });
   });

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const {
   getCategories,
+  getReviews,
   getReviewById,
   patchReview,
   getUsers,
@@ -16,6 +17,8 @@ const app = express();
 app.use(express.json());
 
 app.get("/api/categories", getCategories);
+
+app.get("/api/reviews", getReviews);
 
 app.get("/api/reviews/:review_id", getReviewById);
 app.patch("/api/reviews/:review_id", patchReview);

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -3,6 +3,7 @@ const {
   selectReview,
   updateReview,
   fetchUsers,
+  fetchReviews,
 } = require("../models/models");
 
 exports.getCategories = (req, res, next) => {
@@ -37,5 +38,11 @@ exports.patchReview = (req, res, next) => {
 exports.getUsers = (req, res, next) => {
   fetchUsers().then((users) => {
     res.status(200).send({ users });
+  });
+};
+
+exports.getReviews = (req, res, next) => {
+  fetchReviews().then((reviews) => {
+    res.status(200).send({ reviews });
   });
 };

--- a/models/models.js
+++ b/models/models.js
@@ -44,3 +44,14 @@ exports.updateReview = (review_id, voteChange) => {
 exports.fetchUsers = () => {
   return db.query("SELECT * FROM users").then(({ rows: users }) => users);
 };
+
+exports.fetchReviews = () => {
+  return db
+    .query(
+      `SELECT reviews.*, COUNT(comments.review_id)::int AS comment_count FROM reviews
+       LEFT OUTER JOIN comments ON comments.review_id = reviews.review_id
+       GROUP BY reviews.review_id
+       ORDER BY reviews.created_at DESC`
+    )
+    .then(({ rows: reviews }) => reviews);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "husky": "^7.0.0",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.14",
         "supertest": "^6.2.4"
       }
     },
@@ -3167,6 +3168,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7415,6 +7422,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "husky": "^7.0.0",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.14",
     "supertest": "^6.2.4"
   },
   "jest": {


### PR DESCRIPTION
**GET /api/reviews**

Added /api/reviews as an endpoint and added functionality for the GET method to return all review objects. The database query also includes the addition of comment_count as a property on the review object and automatic sorting of the results array in reverse date order.