### PR TITLE
Add /api/reviews/:review_id/comments as endpoint with the GET method

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -275,3 +275,61 @@ describe("/api/reviews", () => {
     });
   });
 });
+
+describe("/api/reviews/:review_id/comments", () => {
+  describe("GET", () => {
+    test("return a status code of 200", () => {
+      return request(app).get("/api/reviews/2/comments").expect(200);
+    });
+    test("return an array of all corresponding comments on the key of comments where review has comments", () => {
+      return request(app)
+        .get("/api/reviews/2/comments")
+        .then(({ body }) => {
+          expect(body.comments).toBeInstanceOf(Array);
+          expect(body.comments).toHaveLength(3);
+        });
+    });
+    test("return an empty array on the key of comments where review has no comments", () => {
+      return request(app)
+        .get("/api/reviews/1/comments")
+        .then(({ body }) => {
+          expect(body.comments).toBeInstanceOf(Array);
+          expect(body.comments).toHaveLength(0);
+        });
+    });
+    test("all returned comment objects have the correct properties", () => {
+      return request(app)
+        .get("/api/reviews/2/comments")
+        .then(({ body }) => {
+          body.comments.forEach((comment) => {
+            expect(comment).toEqual(
+              expect.objectContaining({
+                comment_id: expect.any(Number),
+                votes: expect.any(Number),
+                created_at: expect.any(String),
+                author: expect.any(String),
+                body: expect.any(String),
+                review_id: 2,
+              })
+            );
+          });
+        });
+    });
+    test("return a status code of 404 and error message when passed a valid id not matching a review in the database", () => {
+      return request(app)
+        .get("/api/reviews/100000/comments")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Review does not exist");
+        });
+    });
+    test("return a status code of 400 and error message when passed an invalid id", () => {
+      return request(app)
+        .get("/api/reviews/banana/comments")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Invalid PSQL input");
+        });
+    });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const {
   getReviewById,
   patchReview,
   getUsers,
+  getCommentsByReviewId,
 } = require("./controllers/controllers");
 const {
   handleCustomErrors,
@@ -22,6 +23,8 @@ app.get("/api/reviews", getReviews);
 
 app.get("/api/reviews/:review_id", getReviewById);
 app.patch("/api/reviews/:review_id", patchReview);
+
+app.get("/api/reviews/:review_id/comments", getCommentsByReviewId);
 
 app.get("/api/users", getUsers);
 

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -4,6 +4,7 @@ const {
   updateReview,
   fetchUsers,
   fetchReviews,
+  fetchCommentsByReviewId,
 } = require("../models/models");
 
 exports.getCategories = (req, res, next) => {
@@ -45,4 +46,15 @@ exports.getReviews = (req, res, next) => {
   fetchReviews().then((reviews) => {
     res.status(200).send({ reviews });
   });
+};
+
+exports.getCommentsByReviewId = (req, res, next) => {
+  const { review_id } = req.params;
+  Promise.all([fetchCommentsByReviewId(review_id), selectReview(review_id)])
+    .then(([comments]) => {
+      res.status(200).send({ comments });
+    })
+    .catch((err) => {
+      next(err);
+    });
 };

--- a/models/models.js
+++ b/models/models.js
@@ -55,3 +55,11 @@ exports.fetchReviews = () => {
     )
     .then(({ rows: reviews }) => reviews);
 };
+
+exports.fetchCommentsByReviewId = (review_id) => {
+  return db
+    .query("SELECT * FROM comments WHERE review_id = $1", [review_id])
+    .then(({ rows: comments }) => {
+      return comments;
+    });
+};


### PR DESCRIPTION
**GET /api/reviews/:review_id/comments**

Added ability to make a GET request to /api/reviews/:review_id/comments endpoint, returning an array of comment objects for the associated review_id.

**Error handling**

Added error handling for valid review IDs not yet in the database (404) and bad requests with invalid IDs (400).