### PR TITLE
Add queries for /api/reviews endpoint and error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -273,6 +273,70 @@ describe("/api/reviews", () => {
           expect(body.reviews).toBeSortedBy("created_at", { descending: true });
         });
     });
+    test("reviews are returned in ascending order according to date when order=asc is passed as a query", () => {
+      return request(app)
+        .get("/api/reviews?order=asc")
+        .then(({ body }) => {
+          expect(body.reviews).toBeSortedBy("created_at");
+        });
+    });
+    test("reviews are sorted by a custom, valid field with the sort_by query", () => {
+      return request(app)
+        .get("/api/reviews?sort_by=votes")
+        .then(({ body }) => {
+          expect(body.reviews).toBeSortedBy("votes", { descending: true });
+        });
+    });
+    test("reviews are sorted by a custom, valid field with the sort_by query and ordered in asc order with the order query", () => {
+      return request(app)
+        .get("/api/reviews?sort_by=votes&order=asc")
+        .then(({ body }) => {
+          expect(body.reviews).toBeSortedBy("votes");
+        });
+    });
+    test("reviews are filtered by a category query", () => {
+      return request(app)
+        .get("/api/reviews?category=euro+game")
+        .then(({ body }) => {
+          body.reviews.forEach((review) => {
+            expect(review.category).toBe("euro game");
+          });
+        });
+    });
+    test("returns correct data when all queries are used to filter, order and sort", () => {
+      return request(app)
+        .get("/api/reviews?sort_by=owner&order=asc&category=social+deduction")
+        .then(({ body }) => {
+          expect(body.reviews).toBeSortedBy("owner");
+          body.reviews.forEach((review) => {
+            expect(review.category).toBe("social deduction");
+          });
+        });
+    });
+    test("returns a 400 status code and error message when the user inputs an invalid sort_by query", () => {
+      return request(app)
+        .get("/api/reviews?sort_by=dogs")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Invalid sort_by query");
+        });
+    });
+    test("returns a 400 status code and error message when the user inputs an invalid order query", () => {
+      return request(app)
+        .get("/api/reviews?order=alphabetical")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Invalid order query");
+        });
+    });
+    test("returns a 404 status code and error message when the user inputs a category query that doesn't exist", () => {
+      return request(app)
+        .get("/api/reviews?category=123")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Category does not exist");
+        });
+    });
   });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -329,12 +329,20 @@ describe("/api/reviews", () => {
           expect(body.msg).toBe("Invalid order query");
         });
     });
-    test("returns a 404 status code and error message when the user inputs a category query that doesn't exist", () => {
+    test("returns a 404 status code and error message when the user inputs a category query that doesn't exist in the database", () => {
       return request(app)
         .get("/api/reviews?category=123")
         .expect(404)
         .then(({ body }) => {
-          expect(body.msg).toBe("Category does not exist");
+          expect(body.msg).toBe("Resource not found in the database");
+        });
+    });
+    test("returns a 404 status code and error message when the user inputs a category query that exists but has no reviews", () => {
+      return request(app)
+        .get("/api/reviews?category=children's+games")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("This category has no associated reviews");
         });
     });
   });

--- a/__tests__/checkExists.test.js
+++ b/__tests__/checkExists.test.js
@@ -1,0 +1,17 @@
+const { checkExists } = require("../utils/checkExists");
+
+describe("checkExists function", () => {
+  test("does not return a promise if item exists in the correct table and column", () => {
+    return checkExists("reviews", "review_id", 1).then((output) => {
+      expect(output).not.toBeInstanceOf(Promise);
+    });
+  });
+  test("returns a rejected promise if item is valid but does not exist in the correct table and column", () => {
+    return checkExists("reviews", "review_id", 10000).catch((error) => {
+      expect(error).toEqual({
+        status: 404,
+        msg: "Resource not found in the database",
+      });
+    });
+  });
+});

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -44,9 +44,14 @@ exports.getUsers = (req, res, next) => {
 };
 
 exports.getReviews = (req, res, next) => {
-  fetchReviews().then((reviews) => {
-    res.status(200).send({ reviews });
-  });
+  const { sort_by, order, category } = req.query;
+  fetchReviews(sort_by, order, category)
+    .then((reviews) => {
+      res.status(200).send({ reviews });
+    })
+    .catch((err) => {
+      next(err);
+    });
 };
 
 exports.getCommentsByReviewId = (req, res, next) => {

--- a/models/models.js
+++ b/models/models.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection");
+const { checkExists } = require("../utils/checkExists");
 
 exports.fetchCategories = () => {
   return db.query("SELECT * FROM categories").then(({ rows: categories }) => {
@@ -82,7 +83,12 @@ exports.fetchReviews = (sort_by = "created_at", order = "desc", category) => {
 
   return db.query(queryString, categoryQuery).then(({ rows: reviews }) => {
     if (reviews.length === 0) {
-      return Promise.reject({ status: 404, msg: "Category does not exist" });
+      return checkExists("categories", "slug", category).then(() => {
+        return Promise.reject({
+          status: 404,
+          msg: "This category has no associated reviews",
+        });
+      });
     } else {
       return reviews;
     }

--- a/models/models.js
+++ b/models/models.js
@@ -45,15 +45,48 @@ exports.fetchUsers = () => {
   return db.query("SELECT * FROM users").then(({ rows: users }) => users);
 };
 
-exports.fetchReviews = () => {
-  return db
-    .query(
-      `SELECT reviews.*, COUNT(comments.review_id)::int AS comment_count FROM reviews
-       LEFT OUTER JOIN comments ON comments.review_id = reviews.review_id
-       GROUP BY reviews.review_id
-       ORDER BY reviews.created_at DESC`
-    )
-    .then(({ rows: reviews }) => reviews);
+exports.fetchReviews = (sort_by = "created_at", order = "desc", category) => {
+  const validSortByQueries = [
+    "review_id",
+    "title",
+    "category",
+    "designer",
+    "owner",
+    "review_body",
+    "review_img_url",
+    "created_at",
+    "votes",
+    "comment_count",
+  ];
+  const validOrderQueries = ["asc", "desc"];
+
+  if (!validSortByQueries.includes(sort_by)) {
+    return Promise.reject({ status: 400, msg: "Invalid sort_by query" });
+  }
+
+  if (!validOrderQueries.includes(order)) {
+    return Promise.reject({ status: 400, msg: "Invalid order query" });
+  }
+
+  let queryString = `SELECT reviews.*, COUNT(comments.review_id)::int AS comment_count FROM reviews
+                        LEFT OUTER JOIN comments ON comments.review_id = reviews.review_id `;
+  const categoryQuery = [];
+
+  if (category) {
+    queryString += `WHERE reviews.category = $1`;
+    categoryQuery.push(category);
+  }
+
+  queryString += `GROUP BY reviews.review_id 
+                  ORDER BY reviews.${sort_by} ${order}`;
+
+  return db.query(queryString, categoryQuery).then(({ rows: reviews }) => {
+    if (reviews.length === 0) {
+      return Promise.reject({ status: 404, msg: "Category does not exist" });
+    } else {
+      return reviews;
+    }
+  });
 };
 
 exports.fetchCommentsByReviewId = (review_id) => {

--- a/utils/checkExists.js
+++ b/utils/checkExists.js
@@ -1,0 +1,15 @@
+const format = require("pg-format");
+const db = require("../db/connection");
+
+exports.checkExists = (table, column, value) => {
+  const queryStr = format(`SELECT * FROM %I WHERE %I = $1`, table, column);
+
+  return db.query(queryStr, [value]).then(({ rows }) => {
+    if (rows.length === 0) {
+      return Promise.reject({
+        status: 404,
+        msg: "Resource not found in the database",
+      });
+    }
+  });
+};


### PR DESCRIPTION
**GET /api/reviews**

Added the ability to query sort_by, order, and category with the /api/reviews endpoint. Results are ordered, sorted, and filtered according to valid queries and can all be used in conjunction with one another.

**Error handling**

Added error handling for invalid order and sort_by queries, as well as returning a 404 error for categories that do not exist. Also implemented a checkExists function to determine if a filter returns zero results because of a bad request or lack of associated data, with relevant error handling.