### PR TITLE
Add /api/comments/:comment endpoint with the DELETE method

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const {
   getUsers,
   getCommentsByReviewId,
   postCommentByReviewId,
+  deleteCommentById,
 } = require("./controllers/controllers");
 const {
   handleCustomErrors,
@@ -29,6 +30,8 @@ app.get("/api/reviews/:review_id/comments", getCommentsByReviewId);
 app.post("/api/reviews/:review_id/comments", postCommentByReviewId);
 
 app.get("/api/users", getUsers);
+
+app.delete("/api/comments/:comment_id", deleteCommentById);
 
 app.all("/*", (req, res) => {
   res.status(404).send({ msg: "Endpoint does not exist" });

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -6,6 +6,7 @@ const {
   fetchReviews,
   fetchCommentsByReviewId,
   addCommentByReviewId,
+  removeComment,
 } = require("../models/models");
 
 exports.getCategories = (req, res, next) => {
@@ -75,6 +76,17 @@ exports.postCommentByReviewId = (req, res, next) => {
   ])
     .then(([review, comment]) => {
       res.status(201).send({ comment });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.deleteCommentById = (req, res, next) => {
+  const { comment_id } = req.params;
+  removeComment(comment_id)
+    .then(() => {
+      res.sendStatus(204);
     })
     .catch((err) => {
       next(err);

--- a/models/models.js
+++ b/models/models.js
@@ -127,3 +127,17 @@ exports.addCommentByReviewId = (review_id, body, author) => {
       return comment[0];
     });
 };
+
+exports.removeComment = (comment_id) => {
+  return db
+    .query("DELETE FROM comments WHERE comment_id = $1 RETURNING *", [
+      comment_id,
+    ])
+    .then(({ rows: comment }) => {
+      if (comment.length === 0) {
+        return Promise.reject({ status: 404, msg: "No comment found" });
+      } else {
+        return;
+      }
+    });
+};


### PR DESCRIPTION
**DELETE /api/comments/:comment **

Allows the DELETE method to be used with /api/comments/:comment_id, removing the specified comment from the database.

**Error handling**

Invalid ID - 400 and error message of "Invalid PSQL input"
Valid but non-existent ID - 404 and error message of "No comment found" 